### PR TITLE
Server config update for Ghost

### DIFF
--- a/nginx/server.conf
+++ b/nginx/server.conf
@@ -38,14 +38,6 @@ server {
     }
 
     # proxy /blog to ghost
-    location = /blog {
-        proxy_set_header Host cucumber.ghost.io;
-        proxy_pass  https://cucumber.ghost.io/;
-    }
-
-    # in case of a trailing slash. this can
-    # likely be lumped together with the above
-    # just need to iron it out first
     location = /blog/ {
         proxy_set_header Host cucumber.ghost.io;
         proxy_pass  https://cucumber.ghost.io/;

--- a/nginx/server.conf
+++ b/nginx/server.conf
@@ -3,6 +3,9 @@ server {
     server_name cucumber.io;
 
     rewrite ^/docs(.*)$                     https://docs.cucumber.io/$1 permanent;
+    
+    # rewrite old blog urls that have dates in the path
+    rewrite ^/blog/(?:[0-9]+)\/(?:[0-9]+)\/(?:[0-9]+)(.*)$ $scheme://$http_host/blog$1 permanent;
 
     # redirect old Ruby API links
     rewrite ^/api/cucumber/ruby/yardoc(.*)$ http://www.rubydoc.info/github/cucumber/cucumber-ruby$1 permanent;
@@ -35,14 +38,29 @@ server {
         proxy_pass        https://cucumber-website.squarespace.com/assets/ui-icons.svg;
     }
 
-    # location ~^/qa/blog/(?:[0-9]{4})/(?:[0-9]{2})/(?:[0-9]{2})/(.*)$ {
-    #     proxy_set_header  Host    cucumber.ghost.io;
-    #     proxy_pass        https://cucumber.ghost.io/$1;
-    # }
+    # proxy /blog to ghost
+    location = /blog {
+        proxy_set_header Host cucumber.ghost.io;
+        proxy_pass  https://cucumber.ghost.io/;
+    }
+
+    # in case of a trailing slash. this can
+    # likely be lumped together with the above
+    # just need to iron it out first
+    location = /blog/ {
+        proxy_set_header Host cucumber.ghost.io;
+        proxy_pass  https://cucumber.ghost.io/;
+    }
+
+    # proxy the posts as linked from /blog
+    location ~ ^/blog/(.*)$ {
+        proxy_set_header Host cucumber.ghost.io;
+        proxy_pass  https://cucumber.ghost.io/blog/$1;
+    }
 
     #
     # old Ruby / Rack app on heroku
-    location ~ ^/(blog|school|training|talks|team|pro|privacy|logo-contest|contact-preferences|feed.xml)(.*)$ {
+    location ~ ^/(school|training|talks|team|pro|privacy|logo-contest|contact-preferences|feed.xml)(.*)$ {
         proxy_set_header  Host    cucumber-website.herokuapp.com;
         proxy_pass        http://cucumber-website.herokuapp.com/$1$2;
     }

--- a/nginx/server.conf
+++ b/nginx/server.conf
@@ -49,6 +49,12 @@ server {
         proxy_pass  https://cucumber.ghost.io/blog/$1;
     }
 
+    # proxy tag routes
+    location ~ ^/tag/(.*)$ {
+        proxy_set_header Host cucumber.ghost.io;
+        proxy_pass  https://cucumber.ghost.io/tag/$1;
+    }
+
     # Old Ruby / Rack app on heroku
     location ~ ^/(school|training|talks|team|pro|privacy|logo-contest|contact-preferences|feed.xml)(.*)$ {
         proxy_set_header  Host    cucumber-website.herokuapp.com;


### PR DESCRIPTION
I've updated the locations in server.conf to handle the new blog. Ghost has also been updated to have blogs at */blog instead of at root. Not merging this as Ghost's theme needs to be updated visually.

Cases:
* cucumber.io/blog
* when a post is clicked from cucumber.io/blog
* when someone accesses a post via an old url i.e. `https://cucumber.io/blog/2018/11/08/agility-in-a-big-organisation`

Right now there are two entries for blog (/blog & /blog/) so that routing works for both. Should probably be cleaned up.