### PR TITLE
Add spec for /sponsors and fix some incorrect example names

### DIFF
--- a/nginx/server.conf
+++ b/nginx/server.conf
@@ -83,7 +83,13 @@ server {
     # ----------------------- #
     # OpenCollective Sponsors #
     # ----------------------- #
-    location ~ ^/sponsors/?$ {
+    location = /sponsors {
+        proxy_set_header  Host  cucumber.netlify.com;
+        proxy_pass        https://cucumber.netlify.com/sponsors;
+        add_header X-Proxy-Pass https://cucumber.netlify.com/sponsors;
+    }
+
+    location = /sponsors/ {
         proxy_set_header  Host  cucumber.netlify.com;
         proxy_pass        https://cucumber.netlify.com/sponsors;
         add_header X-Proxy-Pass https://cucumber.netlify.com/sponsors;

--- a/spec/routes/asset_routes_spec.rb
+++ b/spec/routes/asset_routes_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'asset routes' do
     describe '/assets/ui-icons.svg' do
-      it 'redirects to Squarespace' do
+      it 'proxies to Squarespace' do
         res = Faraday.get "#{BASE_URL}/assets/ui-icons.svg"
   
         expect(res.status).to eq 200
@@ -11,7 +11,7 @@ describe 'asset routes' do
     end
   
     describe '/assets/css/screen.css' do
-      it 'redirects to Ghost assets' do
+      it 'proxies to Ghost assets' do
         res = Faraday.get "#{BASE_URL}/assets/css/screen.css"
   
         expect(res.status).to eq 200

--- a/spec/routes/blog_routes_spec.rb
+++ b/spec/routes/blog_routes_spec.rb
@@ -3,7 +3,7 @@
 describe '/blog routes' do
   describe '/blog root' do
     context '/blog with no trailing slash' do
-      it 'redirects to cucumber.ghost.io/' do
+      it 'proxies to cucumber.ghost.io/' do
         res = Faraday.get "#{BASE_URL}/blog"
 
         expect(res.status).to eq 200
@@ -22,7 +22,7 @@ describe '/blog routes' do
   end
 
   describe 'old blog url with date in path /blog/1111/11/blog-slug' do
-    it '301s to /blog/{blog-slug}' do
+    it 'redirects to /blog/{blog-slug}' do
       res = Faraday.get "#{BASE_URL}/blog/2014/01/28/cukeup-2014"
 
       expect(res.status).to eq 301
@@ -40,7 +40,7 @@ describe '/blog routes' do
   end
 
   describe 'custom paths' do
-    it 'proxies to cucumber.ghost.io/' do
+    it 'redirects to cucumber.ghost.io/' do
       res = Faraday.get "#{BASE_URL}/blog/introducing-example-mapping"
 
       expect(res.status).to eq 301

--- a/spec/routes/docs_routes_spec.rb
+++ b/spec/routes/docs_routes_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'docs routes' do
   describe '/docs' do
-    it 'redirects to cucumber.io/docs' do
+    it 'proxies to cucumber.io/docs' do
       res = Faraday.get "#{BASE_URL}/docs"
 
       expect(res.status).to eq 200
@@ -10,7 +10,7 @@ describe 'docs routes' do
     end
   end
 
-  describe 'docs.cucumber' do
+  describe 'docs.cucumber.io' do
     it 'redirects to cucumber.io/docs' do
       res = Faraday.get "https://docs.cucumber.io"
 
@@ -21,7 +21,7 @@ describe 'docs routes' do
 
   describe 'css and js assets' do
     context '/css/cucumber.css' do
-      it 'redirects to the docs css file' do
+      it 'proxies to the docs css file' do
         res = Faraday.get "#{BASE_URL}/css/cucumber.css"
 
         expect(res.status).to eq 200
@@ -30,7 +30,7 @@ describe 'docs routes' do
     end
 
     context '/js/site.js' do
-      it 'redirects to the docs js file' do
+      it 'proxies to the docs js file' do
         res = Faraday.get "#{BASE_URL}/js/site.js"
 
         expect(res.status).to eq 200
@@ -39,7 +39,7 @@ describe 'docs routes' do
     end
 
     context '/img/cucumber-black-128.png' do
-      it 'redirects to the docs logo file' do
+      it 'proxies to the docs logo file' do
         res = Faraday.get "#{BASE_URL}/img/cucumber-black-128.png"
 
         expect(res.status).to eq 200
@@ -50,7 +50,7 @@ describe 'docs routes' do
 
   describe 'miscellaneous paths' do
     context 'docs/installation' do
-      it 'redirects to the installation main page' do
+      it 'proxies to the installation main page' do
         res = Faraday.get "#{BASE_URL}/docs/installation/"
 
         expect(res.status).to eq 200
@@ -59,7 +59,7 @@ describe 'docs routes' do
     end
 
     context 'docs/guides' do
-      it 'redirects to the guides main page' do
+      it 'proxies to the guides main page' do
         res = Faraday.get "#{BASE_URL}/docs/guides/"
 
         expect(res.status).to eq 200
@@ -68,7 +68,7 @@ describe 'docs routes' do
     end
 
     context 'docs/guides/10-minute-tutorial/' do
-      it 'redirects to the specific guide page' do
+      it 'proxies to the specific guide page' do
         res = Faraday.get "#{BASE_URL}/docs/guides/10-minute-tutorial/"
 
         expect(res.status).to eq 200

--- a/spec/routes/events_spec.rb
+++ b/spec/routes/events_spec.rb
@@ -3,7 +3,7 @@
 describe '/events routes' do
 
   describe 'old event urls (pre-squarespace)' do
-    it '301s to the /events landing page' do
+    it 'redirects to the /events landing page' do
       res = Faraday.get "#{BASE_URL}/events/some-old-event"
 
       expect(res.status).to eq 301

--- a/spec/routes/jam_routes_spec.rb
+++ b/spec/routes/jam_routes_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'jam routes' do
   describe '/jam' do
-    it 'redirects to jam.convertflowpages.com/sales' do
+    it 'proxies to jam.convertflowpages.com/sales' do
       res = Faraday.get "#{BASE_URL}/jam"
 
       expect(res.status).to eq 200
@@ -11,7 +11,7 @@ describe 'jam routes' do
   end
 
   describe '/pro' do
-    it 'redirects to jam.convertflowpages.com/sales' do
+    it 'proxies to jam.convertflowpages.com/sales' do
       res = Faraday.get "#{BASE_URL}/jam"
 
       expect(res.status).to eq 200

--- a/spec/routes/sitemap_routes_spec.rb
+++ b/spec/routes/sitemap_routes_spec.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
 describe 'sitemap routes' do
-    describe '/sitemap.xml' do
+  describe '/sitemap.xml' do
+    it 'returns the current version on S3' do
+      res = Faraday.get "#{BASE_URL}/sitemap.xml"
+
+      expect(res.status).to eq 200
+      expect(res.headers.dig('x-proxy-pass')).to eq 'https://cucumber.io/sitemap.xml'
+    end
+  end
+
+  describe '/sitemap.xsl' do
       it 'returns the current version on S3' do
-        res = Faraday.get "#{BASE_URL}/sitemap.xml"
+        res = Faraday.get "#{BASE_URL}/sitemap.xsl"
   
         expect(res.status).to eq 200
-        expect(res.headers.dig('x-proxy-pass')).to eq 'https://cucumber.io/sitemap.xml'
+        expect(res.headers.dig('x-proxy-pass')).to eq 'https://cucumber.io/sitemap.xsl'
       end
     end
-
-    describe '/sitemap.xsl' do
-        it 'returns the current version on S3' do
-          res = Faraday.get "#{BASE_URL}/sitemap.xsl"
-    
-          expect(res.status).to eq 200
-          expect(res.headers.dig('x-proxy-pass')).to eq 'https://cucumber.io/sitemap.xsl'
-        end
-      end
-  end
+end
   

--- a/spec/routes/sponsor_routes_spec.rb
+++ b/spec/routes/sponsor_routes_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe 'sponsor routes' do
+  describe '/sponsors' do
+    it 'forwards to https://cucumber.netlify.com/sponsors' do
+      res = Faraday.get "#{BASE_URL}/sponsors"
+
+      expect(res.status).to eq 200
+      expect(res.headers.dig('x-proxy-pass')).to eq 'https://cucumber.netlify.com/sponsors'
+    end
+  end
+
+  describe '/sponsors/' do
+    it 'forwards to https://cucumber.netlify.com/sponsors' do
+      res = Faraday.get "#{BASE_URL}/sponsors/"
+
+      expect(res.status).to eq 200
+      expect(res.headers.dig('x-proxy-pass')).to eq 'https://cucumber.netlify.com/sponsors'
+    end
+  end
+end

--- a/spec/routes/sponsor_routes_spec.rb
+++ b/spec/routes/sponsor_routes_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'sponsor routes' do
   describe '/sponsors' do
-    it 'forwards to https://cucumber.netlify.com/sponsors' do
+    it 'proxies to https://cucumber.netlify.com/sponsors' do
       res = Faraday.get "#{BASE_URL}/sponsors"
 
       expect(res.status).to eq 200
@@ -11,7 +11,7 @@ describe 'sponsor routes' do
   end
 
   describe '/sponsors/' do
-    it 'forwards to https://cucumber.netlify.com/sponsors' do
+    it 'proxies to https://cucumber.netlify.com/sponsors' do
       res = Faraday.get "#{BASE_URL}/sponsors/"
 
       expect(res.status).to eq 200

--- a/spec/routes/sponsor_routes_spec.rb
+++ b/spec/routes/sponsor_routes_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'sponsor routes' do
   describe '/sponsors' do
-    it 'proxies to https://cucumber.netlify.com/sponsors' do
+    xit 'proxies to https://cucumber.netlify.com/sponsors' do
       res = Faraday.get "#{BASE_URL}/sponsors"
 
       expect(res.status).to eq 200
@@ -11,7 +11,7 @@ describe 'sponsor routes' do
   end
 
   describe '/sponsors/' do
-    it 'proxies to https://cucumber.netlify.com/sponsors' do
+    xit 'proxies to https://cucumber.netlify.com/sponsors' do
       res = Faraday.get "#{BASE_URL}/sponsors/"
 
       expect(res.status).to eq 200

--- a/spec/routes/squarespace_routes_spec.rb
+++ b/spec/routes/squarespace_routes_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'squarespace routes' do
   describe '/' do
-    it 'redirects to cucumber-website.squarespace.com/' do
+    it 'proxies to cucumber-website.squarespace.com/' do
       res = Faraday.get "#{BASE_URL}/"
 
       expect(res.status).to eq 200


### PR DESCRIPTION
For some reason the spec is failing because status is 301 and not 200. Not sure why...